### PR TITLE
Sutaisyti autentifikacijos el.pašto patikrinimo mazgo grąžinamą statuso kodą

### DIFF
--- a/server/app/src/main/java/lt/gathertime/server/controller/AuthenticationController.java
+++ b/server/app/src/main/java/lt/gathertime/server/controller/AuthenticationController.java
@@ -35,6 +35,6 @@ public class AuthenticationController {
 
     @GetMapping("/check-email/{email}")
     public ResponseEntity<UserResponseDTO> checkEmail(@PathVariable("email") String email){
-        return ResponseEntity.ok(UserMapper.toDto(userRepository.findByEmail(email).orElseThrow()));
+        return ResponseEntity.ofNullable(userRepository.findByEmail(email).map(UserMapper::toDto).orElse(null));
     }
 }


### PR DESCRIPTION
Autentifikacijos mazgas `GET /auth/check-email/{email}` klaidingai grąžina HTTP protokolo statuso kodą `500`, kuomet duomenų bazėje nebūna įrašo:
```
java.util.NoSuchElementException: No value present
	at java.base/java.util.Optional.orElseThrow(Optional.java:377) ~[na:na]
	at lt.gathertime.server.controller.AuthenticationController.checkEmail(AuthenticationController.java:38) ~[main/:na]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:565) ~[na:na]
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:258) ~[spring-web-6.2.12.jar:6.2.12]
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:191) ~[spring-web-6.2.12.jar:6.2.12]
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:118) ~[spring-webmvc-6.2.12.jar:6.2.12]
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:991) ~[spring-webmvc-6.2.12.jar:6.2.12]
```

Pagal RESTful programavimo sąsajos principus, kuomet resursas nebūna surastas, rezultatas iš mazgo turi būti grąžintas su HTTP protokolo `404` statusu. Šis kodo pakeitimas tai sutaiso grąžinant galimai tusčią `ResponseEntity` objektą, kuris implikuoja šio statuso išsiuntimą į klientą.