### PR TITLE
Pakoreguoti „.gitignore“ failus, kad geriau atitiktų reikalingų failų saugykloje, pagal nutylėjimą, tvarką

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 # Ignore dotenv files
 .env
+.env.*
+
+# Ignore build specific directories
+build/
+bin/
 
 # Ignore IDE-specific directories
 .idea/

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,3 +1,2 @@
 # Ignore artifact directories
 node_modules/
-dist/

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,5 +1,2 @@
 # Ignore Gradle project-specific cache directory
 .gradle
-
-# Ignore Gradle build output directory
-build


### PR DESCRIPTION
# Smulkmeninė problema
Įkeliant failus į saugyklą, pagal nutylėjimą yra ignoruojami  nereiškmingi failai, tačiau dabartinė konfiguracija praleidžia tam tikrus su technologijomis susijusius failus kliento bei serverio direktorijose.

## Sprendimas
- Pakoreguoti už saugykloje esančių failų ignoravimą atsakingus „.gitignore“ failus, kad geriau atitiktų reikalingų failų, pagal nutylėjimą, tvarką bei atitiktų šiandieninius poreikius saugykloje.